### PR TITLE
1.7.7-pg11: update go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG PREV_EXTRA
 ############################
 # Build tools binaries in separate image
 ############################
-ARG GO_VERSION=1.14.0
+ARG GO_VERSION=1.21.6
 FROM golang:${GO_VERSION}-alpine AS tools
 
 ENV TOOLS_VERSION 0.8.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,5 @@ RUN set -ex \
     \
     && if [ "${OSS_ONLY}" != "" ]; then rm -f $(pg_config --pkglibdir)/timescaledb-tsl-*.so; fi \
     && apk del .fetch-deps .build-deps \
-    && apk add --no-cache openssl1.1-compat \
     && rm -rf /build \
     && sed -r -i "s/[#]*\s*(shared_preload_libraries)\s*=\s*'(.*)'/\1 = 'timescaledb,\2'/;s/,'/'/" /usr/local/share/postgresql/postgresql.conf.sample


### PR DESCRIPTION
- Installation of `openssl-compat` was removed as it is no longer necessary (see [x](https://gitlab.alpinelinux.org/alpine/aports/-/issues/15575))
- Default `GO_VERSION` build arg was updated to `1.21.6`, which also indirectly updated the alpine version from `3.17.3` to `3.19.0`