### PR TITLE
update go (1.22) and update libraries for vulnerability fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG PREV_EXTRA
 ############################
 # Build tools binaries in separate image
 ############################
-ARG GO_VERSION=1.21.6
+ARG GO_VERSION=1.22
 FROM golang:${GO_VERSION}-alpine AS tools
 
 ENV TOOLS_VERSION 0.8.1
@@ -21,7 +21,8 @@ RUN apk update && apk add --no-cache git \
     && go build -o /go/bin/timescaledb-tune \
     # Build timescaledb-parallel-copy
     && cd ${GOPATH}/src/github.com/timescale/timescaledb-parallel-copy/cmd/timescaledb-parallel-copy \
-    && git fetch && git checkout --quiet $(git describe --abbrev=0) \
+    && git fetch \
+    && git checkout main \
     && go get -d -v \
     && go build -o /go/bin/timescaledb-parallel-copy
 
@@ -55,6 +56,7 @@ COPY --from=oldversions /usr/local/lib/postgresql/timescaledb-*.so /usr/local/li
 COPY --from=oldversions /usr/local/share/postgresql/extension/timescaledb--*.sql /usr/local/share/postgresql/extension/
 
 RUN set -ex \
+    && apk update && apk upgrade --no-cache \
     && apk add --no-cache --virtual .fetch-deps \
                 ca-certificates \
                 git \


### PR DESCRIPTION
This PR does the following:

1. Updates go: 1.21.6 -> 1.22
2. Uses main branch for fetching https://github.com/sfarqu/timescaledb-parallel-copy (returning old vulnerabilities without it) [ screenshot attached ]
<img width="1207" alt="Screenshot 2024-08-21 at 12 58 26 AM" src="https://github.com/user-attachments/assets/4f077b88-b344-4b9c-ab62-94415469bdfb">

3. Uses updated libraries for fixing:
<img width="1111" alt="Screenshot 2024-08-21 at 12 59 04 AM" src="https://github.com/user-attachments/assets/72b38fda-a129-4ae8-9500-1331646d2ac3">

After scan:
<img width="476" alt="Screenshot 2024-08-21 at 12 59 48 AM" src="https://github.com/user-attachments/assets/b054c6c4-086b-42a5-8499-db1bd1ee0086">

